### PR TITLE
compare filesystem vs database via array_diff_key rather than array_diff...

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -184,7 +184,7 @@ class report_filetrash {
     public function get_orphaned_files() {
         $indexedorphans = array();
         $currentfiles = array_merge($this->directoryfiles, $this->backupfiles);
-        $orphans = array_diff_assoc($currentfiles, $this->dbfiles);
+        $orphans = array_diff_key($currentfiles, $this->dbfiles);
         $i = 0;
         foreach ($orphans as $orphan) {
             $i++;


### PR DESCRIPTION
This gets rid of the error about "Array to string conversion".  It should be tested on a system with few orphan files. Ours has so many orphan files that it is hard to know if the list os correct or not.